### PR TITLE
bump component classes. add node_modules to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 components
 build
+node_modules

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "main": "./index.js",
   "dependencies": {
-    "component-classes": "1.2.2",
+    "component-classes": "1.2.4",
     "uniq-component": "defunctzombie/uniq#36a99d1c"
   },
   "browser": {


### PR DESCRIPTION
fixes `classes(svg_element).array()`
